### PR TITLE
fix(security): remove exposed API keys

### DIFF
--- a/src/constants/coingecko.ts
+++ b/src/constants/coingecko.ts
@@ -1,2 +1,2 @@
 export const coingeckoProApiBaseUrl = 'https://pro-api.coingecko.com/api/v3'
-export const coingeckoApiKey = 'CG-SfQhb5vwYvnSWjMPZ26CCvJk';
+export const coingeckoApiKey = '';

--- a/src/constants/investments.ts
+++ b/src/constants/investments.ts
@@ -81,14 +81,14 @@ export const CACHE_KEY_INVESTMENTS_INVESTMENTS = 'investments/investments';
 export const CACHE_KEY_INVESTMENTS_PROTOCOLS = 'investments/protocols';
 export const CACHE_KEY_INVESTMENTS_FNFTS = 'investments/fnfts';
 
-export const ftmscanApiKey = '9WPBVWMFKMM96K3X56M65KB67HH1J5GBQT';
-export const bybitApiKey = 'r69fMvdMqp8xNvRt7q';
-export const bybitSecretKey = 'NTmEHxHV4g0PhpK7QVTRIUQ236MNbS3GN01O';
-export const gateioApiKey = 'eb86608f85c6514511681675db2ab301';
-export const gateioSecretKey = '83354cbaa1cb352566ef1cbf412cd670d55f3b958fc7dc5768fc2a6e5d0ddec8';
-export const huobiApiKey = '278fc61d-bewr5drtmh-fb9a49b1-859d8';
-export const huobiSecretKey = '27c8d574-8aa96748-ae00f2d4-d5ed8';
-export const moralisApiKey = '9mZ4GZWP5sf0pOcmsNHJcYaYiaUXuEWmwzLwzTrmcibrcr41Vso2Bdt1imeDIkIA';
+export const ftmscanApiKey = '';
+export const bybitApiKey = '';
+export const bybitSecretKey = '';
+export const gateioApiKey = '';
+export const gateioSecretKey = '';
+export const huobiApiKey = '';
+export const huobiSecretKey = '';
+export const moralisApiKey = '';
 
 export type HuobiAccountBalance = {
     spotBalanceState: number;

--- a/src/constants/protocols.ts
+++ b/src/constants/protocols.ts
@@ -1,4 +1,4 @@
-export const ACCESS_KEY = 'c0d8553d17ccd2c54ddf36e8fe863a0bca47a2b9';
+export const ACCESS_KEY = '';
 
 export const WALLET_1 = '0x4bfb33d65f4167ebe190145939479227e7bf2cb0';
 export const TREASURY_WALLET = '0xcb54ea94191b280c296e6ff0e37c7e76ad42dc6a';

--- a/src/constants/tax.ts
+++ b/src/constants/tax.ts
@@ -1,5 +1,5 @@
 const abiDecoder = require('abi-decoder');
-export const COVALENT_API_KEY = 'ckey_c4b967827969499ea20f75b4c95';
+export const COVALENT_API_KEY = '';
 
 export interface TokenModel {
     chainId?: number;


### PR DESCRIPTION
Coingecko one is already disabled, but
Covalent works. Didn't check other ones.